### PR TITLE
download VEP release 102 instead of 96

### DIFF
--- a/repository/Preparation_GetReferenceDataMouse.sh
+++ b/repository/Preparation_GetReferenceDataMouse.sh
@@ -86,10 +86,10 @@ java -Dpicard.useLegacyParser=false -jar $picard_dir/picard.jar BedToIntervalLis
 echo '---- Downloading reference genome (for VEP) ----' | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"
 date | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"
 
-wget -nv -P "ref/"$VersionMouse"/VEP" ftp://ftp.ensembl.org/pub/release-96/variation/indexed_vep_cache/mus_musculus_vep_96_GRCm38.tar.gz
-tar -xzf "ref/"$VersionMouse"/VEP/mus_musculus_vep_96_GRCm38.tar.gz"
+wget -nv -P "ref/"$VersionMouse"/VEP" ftp://ftp.ensembl.org/pub/release-102/variation/indexed_vep_cache/mus_musculus_vep_102_GRCm38.tar.gz
+tar -xzf "ref/"$VersionMouse"/VEP/mus_musculus_vep_102_GRCm38.tar.gz"
 mv mus_musculus "ref/"$VersionMouse"/VEP/"
-rm "ref/"$VersionMouse"/VEP/mus_musculus_vep_96_GRCm38.tar.gz"
+rm "ref/"$VersionMouse"/VEP/mus_musculus_vep_102_GRCm38.tar.gz"
 
 echo '---- Generate customized Sanger DB ----' | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"
 date | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"

--- a/repository/Preparation_GetReferenceDataMouse.sh
+++ b/repository/Preparation_GetReferenceDataMouse.sh
@@ -86,6 +86,11 @@ java -Dpicard.useLegacyParser=false -jar $picard_dir/picard.jar BedToIntervalLis
 echo '---- Downloading reference genome (for VEP) ----' | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"
 date | tee -a "ref/"$VersionMouse"/GetReferenceData.txt"
 
+wget -nv -P "ref/"$VersionMouse"/VEP" ftp://ftp.ensembl.org/pub/release-96/variation/indexed_vep_cache/mus_musculus_vep_96_GRCm38.tar.gz
+tar -xzf "ref/"$VersionMouse"/VEP/mus_musculus_vep_96_GRCm38.tar.gz"
+mv mus_musculus "ref/"$VersionMouse"/VEP/"
+rm "ref/"$VersionMouse"/VEP/mus_musculus_vep_96_GRCm38.tar.gz"
+
 wget -nv -P "ref/"$VersionMouse"/VEP" ftp://ftp.ensembl.org/pub/release-102/variation/indexed_vep_cache/mus_musculus_vep_102_GRCm38.tar.gz
 tar -xzf "ref/"$VersionMouse"/VEP/mus_musculus_vep_102_GRCm38.tar.gz"
 mv mus_musculus "ref/"$VersionMouse"/VEP/"


### PR DESCRIPTION
Update mouse data preparation with latest VEP data for GRCm38 ( release 102 ) .